### PR TITLE
Add `spec` task to Rakefile and make it default.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,11 @@
 require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 require 'yard'
+
+desc "Run specs"
+task :default => :spec
+
+RSpec::Core::RakeTask.new(:spec)
 
 YARD::Rake::YardocTask.new do |t|
   t.files   = ['lib/**/*.rb']


### PR DESCRIPTION
Being new to a project I'm always typing `rake` in order to run tests/specs.

This PR helps those lazy developers to just type `rake` and NOT worrying about the testing framework :)
