### PR TITLE
Use #each_with_object instead of #inject.

### DIFF
--- a/lib/powerpack/enumerable/frequencies.rb
+++ b/lib/powerpack/enumerable/frequencies.rb
@@ -11,8 +11,8 @@ unless Enumerable.method_defined? :frequencies
     #
     #
     def frequencies
-      inject(Hash.new(0)) do |a, e|
-        a.tap { |acc| acc[e] += 1 }
+      each_with_object(Hash.new(0)) do |e, a|
+        a[e] += 1
       end
     end
   end


### PR DESCRIPTION
Enumerable#inject requires the block to return the accumulator,
as #each_with_object stores the accumulator to be yielded internally.
