### PR TITLE
Make take_last_while return elements in the original order.

### DIFF
--- a/lib/powerpack/enumerable/take_last_while.rb
+++ b/lib/powerpack/enumerable/take_last_while.rb
@@ -12,7 +12,7 @@ unless Enumerable.method_defined? :take_last_while?
       result = []
       reverse_each do |elem|
         return result unless yield(elem)
-        result << elem
+        result.unshift(elem)
       end
 
       result

--- a/spec/powerpack/enumerable/take_last_while_spec.rb
+++ b/spec/powerpack/enumerable/take_last_while_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe 'Enumerable#take_last_while' do
   it 'takes the last elements while a pred is true' do
-    expect([1, 2, 3, 4, 6].take_last_while(&:even?)).to eq([6, 4])
+    expect([1, 2, 3, 4, 6].take_last_while(&:even?)).to eq([4, 6])
   end
 end


### PR DESCRIPTION
As discussed here: http://batsov.com/articles/2013/09/03/a-couple-of-useful-extensions-to-rubys-enumerable-module/#comment-1029299126
