### PR TITLE
Enumerable#exactly? - more examples, more specs

### DIFF
--- a/lib/powerpack/enumerable/exactly.rb
+++ b/lib/powerpack/enumerable/exactly.rb
@@ -14,7 +14,9 @@ unless Enumerable.method_defined? :exactly?
     # This means that nil and false elements will be ignored.
     #
     # @example
-    #   [1, false, nil].exactly? #=> false
+    #   [1, false, nil].exactly?(3) #=> false
+    #   [1, false, nil].exactly?(1) #=> true
+    #   [false, nil].exactly?(0) #=> true
     #   [1, 2, 3].exactly?(3) #=>true
     def exactly?(n)
       found_count = 0

--- a/spec/powerpack/enumerable/exactly_spec.rb
+++ b/spec/powerpack/enumerable/exactly_spec.rb
@@ -16,11 +16,23 @@ describe 'Enumerable#exactly' do
   end
 
   context 'without block' do
-    it 'returns true for exact number of non nil/false elements' do
+    it 'returns true for exact number of non nil/false elements in absence of nil/false elements' do
       expect([1, 2, 3, 4].exactly?(4)).to be_true
     end
 
-    it 'returns false if there are less non nil/false elements' do
+    it 'returns true for exact number of non nil/false elements in presence of nil/false elements' do
+      expect([1, 2, nil, false].exactly?(2)).to be_true
+    end
+
+    it 'returns true for exact number of nil/false elements' do
+      expect([nil, false].exactly?(0)).to be_true
+    end
+
+    it 'returns false if there are less non nil/false elements in absence of nil/false elements' do
+      expect([1, 2, 3].exactly?(4)).to be_false
+    end
+
+    it 'returns false if there are less non nil/false elements in presence of nil/false elements' do
       expect([1, nil, false].exactly?(4)).to be_false
     end
   end


### PR DESCRIPTION
Hey @bbatsov, I noticed that one of the examples for `Enumerable#exactly?` was incorrect, so I fixed it in a way that I hope you originally intended.

In the process, I have also added some more examples, as well as corresponding specs, to better document the behaviour of `Enumerable#exactly?` in the absence of a block.

Thanks for considering this pull request... great little library, BTW!  :smile:

---

Here's what the example resulted in, due to the lack of an argument:

``` ruby
irb(main):001:0> require 'powerpack'
=> true
irb(main):002:0> [1, false, nil].exactly? #=> false
ArgumentError: wrong number of arguments (0 for 1)
    from /Users/pvdb/Workarea/powerpack/lib/powerpack/enumerable/exactly.rb:21:in `exactly?'
    from (irb):2
    from /usr/local/var/rbenv/versions/2.0.0-p195/bin/irb:12:in `<main>'
irb(main):003:0> _
```
