### PR TITLE
I find using if..else easier to understand than unless with early return

### DIFF
--- a/lib/powerpack/enumerable/take_last_while.rb
+++ b/lib/powerpack/enumerable/take_last_while.rb
@@ -10,11 +10,7 @@ unless Enumerable.method_defined? :take_last_while?
       return to_enum(:take_last_while) unless block_given?
 
       result = []
-      reverse_each do |elem|
-        return result unless yield(elem)
-        result.unshift(elem)
-      end
-
+      reverse_each { |elem| yield(elem) ? result.unshift(elem) : break  }
       result
     end
   end


### PR DESCRIPTION
Since we are 'taking in', using the negative logic predicate 'unless yield(elem)' is hard to follow, because that particular elem is the one we are taking in.
