### PR TITLE
Add Hash#map_keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ rvm:
   - jruby-19mode
   - rbx-2
 script: bundle exec rspec
+
+before_install:
+  - gem update bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* Added `Hash#map_values`
+
 ## 0.1.1 (04/05/2015)
 
 No user-visible changes.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Or install it yourself as:
     * [#take_last](http://rdoc.info/github/bbatsov/powerpack/Enumerable#take_last-instance_method)
     * [#take_last_while](http://rdoc.info/github/bbatsov/powerpack/Enumerable#take_last_while-instance_method)
 * [Hash](http://rdoc.info/github/bbatsov/powerpack/Hash)
+    * [#map_values](http://rdoc.info/github/bbatsov/powerpack/Hash#map_values_method)
     * [#symbolize_keys](http://rdoc.info/github/bbatsov/powerpack/Hash#symbolize_keys-instance_method)
 * [Numeric](http://rdoc.info/github/bbatsov/powerpack/Numeric)
     * [#pos?](http://rdoc.info/github/bbatsov/powerpack/Numeric#pos?-instance_method)

--- a/lib/powerpack/hash.rb
+++ b/lib/powerpack/hash.rb
@@ -1,1 +1,2 @@
+require_relative 'hash/map_values'
 require_relative 'hash/symbolize_keys'

--- a/lib/powerpack/hash/map_values.rb
+++ b/lib/powerpack/hash/map_values.rb
@@ -1,0 +1,22 @@
+unless Hash.method_defined? :map_values
+  class Hash
+    # Maps over the hash yielding the key-value pairs. The result of yielding
+    # is used as the value for the giving key in the returned hash.
+    #
+    # @return [Hash]
+    #
+    # @example
+    #   {}.map_values # => {}
+    #
+    #   { first_name: 'john',  last_name: 'doe' }.map_values { |_key, value|
+    #     value.capitalize
+    #   }
+    #
+    #   # => { first_name: 'John', last_name: 'Doe' }
+    #
+    #
+    def map_values(&block)
+      Hash[map { |e| [e.first, yield(*e)] }]
+    end
+  end
+end

--- a/spec/powerpack/hash/map_values_spec.rb
+++ b/spec/powerpack/hash/map_values_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'Hash#map_values' do
+  context 'empty hash' do
+    it 'resolves to an empty hash' do
+      expect({}.map_values).to eql({})
+    end
+  end
+
+  context 'populated hash' do
+    it "maps over the hash's key-value pairs returning a new hash indexed by the original keys" do
+      expect({ 1 => 'one', 2 => 'two', 3 => 'three' }.map_values { |i, name|
+        "#{ i } is #{ name }"
+      } ).to eql(
+        1 => '1 is one',
+        2 => '2 is two',
+        3 => '3 is three')
+    end
+  end
+end


### PR DESCRIPTION
I want to start a discusion about this feature. The main idea of this method is to work like `#map`, except returning a `Hash` instead of an `Array`. I think it's an useful addition, and it simplifies the task of building hashes from arrays - that usually requires using `#each_with_object`.

That said, I'm open to suggestions about pretty much everything; I'm not sure this is a good naming, the examples I used for the specs are far from good and maybe I didn't covered all the possible cases.

Also as a note, theres' an ongoing discussion on the Ruby bug tacker suggesting to add such feature to core (https://bugs.ruby-lang.org/issues/8951).

Nitpicks and feedback are welcome.
