### PR TITLE
Convert specs to RSpec 3.2.3 syntax with Transpec

### DIFF
--- a/powerpack.gemspec
+++ b/powerpack.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency('rspec', '~> 2.13')
+  spec.add_development_dependency('rspec')
   spec.add_development_dependency('yard', '~> 0.8')
 end

--- a/spec/powerpack/enumerable/exactly_spec.rb
+++ b/spec/powerpack/enumerable/exactly_spec.rb
@@ -3,37 +3,37 @@ require 'spec_helper'
 describe 'Enumerable#exactly' do
   context 'with block' do
     it 'returns true for exact number of matches' do
-      expect([1, 2, 3, 4].exactly?(2, &:even?)).to be_true
+      expect([1, 2, 3, 4].exactly?(2, &:even?)).to be_truthy
     end
 
     it 'returns false for less matches' do
-      expect([1, 3, 4].exactly?(2, &:even?)).to be_false
+      expect([1, 3, 4].exactly?(2, &:even?)).to be_falsey
     end
 
     it 'returns false for more matches' do
-      expect([1, 3, 4, 6, 8].exactly?(2, &:even?)).to be_false
+      expect([1, 3, 4, 6, 8].exactly?(2, &:even?)).to be_falsey
     end
   end
 
   context 'without block' do
     it 'returns true for exact number of non nil/false elements in absence of nil/false elements' do
-      expect([1, 2, 3, 4].exactly?(4)).to be_true
+      expect([1, 2, 3, 4].exactly?(4)).to be_truthy
     end
 
     it 'returns true for exact number of non nil/false elements in presence of nil/false elements' do
-      expect([1, 2, nil, false].exactly?(2)).to be_true
+      expect([1, 2, nil, false].exactly?(2)).to be_truthy
     end
 
     it 'returns true for exact number of nil/false elements' do
-      expect([nil, false].exactly?(0)).to be_true
+      expect([nil, false].exactly?(0)).to be_truthy
     end
 
     it 'returns false if there are less non nil/false elements in absence of nil/false elements' do
-      expect([1, 2, 3].exactly?(4)).to be_false
+      expect([1, 2, 3].exactly?(4)).to be_falsey
     end
 
     it 'returns false if there are less non nil/false elements in presence of nil/false elements' do
-      expect([1, nil, false].exactly?(4)).to be_false
+      expect([1, nil, false].exactly?(4)).to be_falsey
     end
   end
 end

--- a/spec/powerpack/enumerable/several_spec.rb
+++ b/spec/powerpack/enumerable/several_spec.rb
@@ -3,25 +3,25 @@ require 'spec_helper'
 describe 'Enumerable#several' do
   context 'with block' do
     it 'returns true if more than 1 element matches the predicate' do
-      expect([1, 2, 3, 4].several?(&:even?)).to be_true
+      expect([1, 2, 3, 4].several?(&:even?)).to be_truthy
     end
 
     it 'returns false if just 1 element matches the predicate' do
-      expect([1, 3, 4].several?(&:even?)).to be_false
+      expect([1, 3, 4].several?(&:even?)).to be_falsey
     end
 
     it 'returns false if no elements match the predicate' do
-      expect([1, 3, 4].several?(&:even?)).to be_false
+      expect([1, 3, 4].several?(&:even?)).to be_falsey
     end
   end
 
   context 'without block' do
     it 'returns true if there are 2 or more non nil/false elements' do
-      expect([1, 2, 3, 4].several?).to be_true
+      expect([1, 2, 3, 4].several?).to be_truthy
     end
 
     it 'returns false if there are less than 2 non nil/false elements' do
-      expect([1, nil, false].several?).to be_false
+      expect([1, nil, false].several?).to be_falsey
     end
   end
 end

--- a/spec/powerpack/numeric/neg_spec.rb
+++ b/spec/powerpack/numeric/neg_spec.rb
@@ -2,23 +2,23 @@ require 'spec_helper'
 
 describe 'Numeric#neg?' do
   it 'returns false for positive integer' do
-    expect(1.neg?).to be_false
+    expect(1.neg?).to be_falsey
   end
 
   it 'returns false for positive float' do
-    expect(0.1.neg?).to be_false
+    expect(0.1.neg?).to be_falsey
   end
 
   it 'returns true for negative integer' do
-    expect(-1.neg?).to be_true
+    expect(-1.neg?).to be_truthy
   end
 
   it 'returns true for negative float' do
-    expect(-0.01.neg?).to be_true
+    expect(-0.01.neg?).to be_truthy
   end
 
   it 'returns false for 0' do
-    expect(0.neg?).to be_false
-    expect(0.0.neg?).to be_false
+    expect(0.neg?).to be_falsey
+    expect(0.0.neg?).to be_falsey
   end
 end

--- a/spec/powerpack/numeric/pos_spec.rb
+++ b/spec/powerpack/numeric/pos_spec.rb
@@ -2,23 +2,23 @@ require 'spec_helper'
 
 describe 'Numeric#pos?' do
   it 'returns true for positive integer' do
-    expect(1.pos?).to be_true
+    expect(1.pos?).to be_truthy
   end
 
   it 'returns true for positive float' do
-    expect(0.1.pos?).to be_true
+    expect(0.1.pos?).to be_truthy
   end
 
   it 'returns false for negative integer' do
-    expect(-1.pos?).to be_false
+    expect(-1.pos?).to be_falsey
   end
 
   it 'returns false for negative float' do
-    expect(-0.01.pos?).to be_false
+    expect(-0.01.pos?).to be_falsey
   end
 
   it 'returns false for 0' do
-    expect(0.pos?).to be_false
-    expect(0.0.pos?).to be_false
+    expect(0.pos?).to be_falsey
+    expect(0.0.pos?).to be_falsey
   end
 end

--- a/spec/powerpack/string/blank_spec.rb
+++ b/spec/powerpack/string/blank_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe 'String#blank?' do
   it 'returns true for an empty string' do
-    expect(''.blank?).to be_true
+    expect(''.blank?).to be_truthy
   end
 
   it 'returns true for a string with only whitespace in it' do
-    expect('     '.blank?).to be_true
+    expect('     '.blank?).to be_truthy
   end
 
   it 'returns false for a string with non-whitespace chars in it' do
-    expect('   test'.blank?).to be_false
+    expect('   test'.blank?).to be_falsey
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,6 @@ require 'rspec'
 require 'powerpack'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
-
   config.expect_with :rspec do |c|
     c.syntax = :expect # disables `should`
   end


### PR DESCRIPTION
* Unpin rspec (bump to 3.x)
* Convert tests to RSpec3 syntax
* Remove outadted RSpec options

Refs: https://bugs.debian.org/783992 (thx Cédric)