### PR TITLE
remove_{prefix,suffix} returns the original string if the param is not a prefix/suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+* Changed `String#remove_prefix` returns the original string if the parameter is not a prefix
+* Changed `String#remove_prefix!`returns the original string if the parameter is not a prefix
+* Changed `String#remove_suffix` returns the original string if the parameter is not a suffix
+* Changed `String#remove_suffix!` returns the original string if the parameter is not a suffix
+
 ## 0.1.1 (04/05/2015)
 
 No user-visible changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## master (unreleased)
 
-* Changed `String#remove_prefix` returns the original string if the parameter is not a prefix
-* Changed `String#remove_prefix!`returns the original string if the parameter is not a prefix
-* Changed `String#remove_suffix` returns the original string if the parameter is not a suffix
-* Changed `String#remove_suffix!` returns the original string if the parameter is not a suffix
+* Changed `String#remove_prefix` to return the original string if the parameter is not a prefix
+* Changed `String#remove_prefix!`to return the original string if the parameter is not a prefix
+* Changed `String#remove_suffix` to return the original string if the parameter is not a suffix
+* Changed `String#remove_suffix!` to return the original string if the parameter is not a suffix
 
 ## 0.1.1 (04/05/2015)
 

--- a/lib/powerpack/string/remove_prefix.rb
+++ b/lib/powerpack/string/remove_prefix.rb
@@ -18,6 +18,7 @@ unless String.method_defined? :remove_prefix
     #   'Ladies Night'.remove_prefix!('Ladies ') #=> 'Night'
     def remove_prefix!(pattern)
       gsub!(/\A#{pattern}/, '')
+      self
     end
   end
 end

--- a/lib/powerpack/string/remove_suffix.rb
+++ b/lib/powerpack/string/remove_suffix.rb
@@ -18,6 +18,7 @@ unless String.method_defined? :remove_suffix
     #   'Ladies Night'.remove_suffix!(' Night') #=> 'Ladies'
     def remove_suffix!(pattern)
       gsub!(/#{pattern}\z/, '')
+      self
     end
   end
 end

--- a/spec/powerpack/string/remove_prefix_spec.rb
+++ b/spec/powerpack/string/remove_prefix_spec.rb
@@ -4,10 +4,18 @@ describe 'String#remove_prefix' do
   it 'removes a prefix in a string' do
     expect('Ladies Night'.remove_prefix('Ladies ')).to eq('Night')
   end
+
+  it 'return the original string if the parameter is not a prefix' do
+    expect('Ladies Night'.remove_prefix('Night')).to eq('Ladies Night')
+  end
 end
 
 describe 'String#remove_prefix!' do
   it 'removes a prefix in a string' do
     expect('Ladies Night'.remove_prefix!('Ladies ')).to eq('Night')
+  end
+
+  it 'return the original string if the parameter is not a prefix' do
+    expect('Ladies Night'.remove_prefix!('Night')).to eq('Ladies Night')
   end
 end

--- a/spec/powerpack/string/remove_suffix_spec.rb
+++ b/spec/powerpack/string/remove_suffix_spec.rb
@@ -4,10 +4,18 @@ describe 'String#remove_suffix' do
   it 'removes a suffix in a string' do
     expect('Ladies Night'.remove_suffix(' Night')).to eq('Ladies')
   end
+
+  it 'return the original string if the parameter is not a suffix' do
+    expect('Ladies Night'.remove_suffix('Ladies')).to eq('Ladies Night')
+  end
 end
 
 describe 'String#remove_suffix!' do
   it 'removes a suffix in a string' do
     expect('Ladies Night'.remove_suffix!(' Night')).to eq('Ladies')
+  end
+
+  it 'return the original string if the parameter is not a suffix' do
+    expect('Ladies Night'.remove_suffix!('Ladies')).to eq('Ladies Night')
   end
 end


### PR DESCRIPTION
(gsub! returns nil when no substitution is performed)
